### PR TITLE
Added location of  settings page to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You'll need a web browser and access to a printer.
 
 ## Extension Settings
 
-This extension contributes the following settings:
+This extension has the following settings, which can be modified by going to Code > Preferences > Settings > Extensions > Printing:
 
 * `print.alternateBrowser`: enable/disable an alternate browser
 * `print.announcePortAcquisition`: make the embedded web server tell you what port it uses


### PR DESCRIPTION
Looking at existing documentation, it was not clear that there is a GUI way to change settings. I clarified this.

I was also thinking that for consistency, the title under Extensions should either be "VS Code Printing" (name of the extension) or "Print" (the name under which the commands are filed).

I am a noob, but if you are interested in one  or the other of those changes I could try to add to this PR, or create a new one.

Thanks!