### PR TITLE
print.editorTitleMenuButton setting, and update menu contributions on settings change

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -31,6 +31,7 @@ This extension has the following settings, which can be modified by going to Cod
 * `print.dynamicPortMax` : the upper bound of the range in which the embedded webserver will choose ports
 * `print.dynamicPortMin` : the lower bound of the range in which the embedded webserver will choose ports
 * `print.editorContextMenuItemPosition` : the position of `Print` in the editor context menu
+* `print.editorTitleMenuButton` : show print button in the editor title menu
 * `print.fontSize` : the font size (options from 9 to 13 pt)
 * `print.formatMarkdown` : render markdown as styled HTML when printing
 * `print.lineNumbers` : on, off or inherit (do same as editor)

--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
 							"None"
 						]
 					},
+					"print.editorTitleMenuButton": {
+						"default": true,
+						"type": "boolean",
+            "description": "%print.editorTitleMenuButton.description%"
+					},
 					"print.dynamicPortMin": {
 						"title": "dynoportmin",
 						"type": "integer",
@@ -148,7 +153,7 @@
 			],
 			"editor/title": [
 				{
-					"when": "editorLangId",
+					"when": "editorLangId && etmButton",
 					"command": "extension.print",
 					"group": "navigation"
 				}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 						"description": "%print.browserPath.description%"
 					},
 					"print.colourScheme": {
-						"title": "I'm calling this a potato",
+						"title": "%print.colourScheme.title%",
 						"type": "string",
 						"default": "vs2015",
 						"markdownDescription": "%print.colourScheme.markdownDescription%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -29,6 +29,8 @@
 	"print.editorContextMenuItemPosition.title": "Editor context-menu position",
 	"print.editorContextMenuItemPosition.markdownDescription": "The position of `Print` in the editor context menu",
 
+  "print.editorTitleMenuButton.description": "Show print button in the editor title menu",
+
 	"print.dynamicPortMax.title": "Maximum dynamic port",
 	"print.dynamicPortMax.description": "End of the range in which a free port will be sought",
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ const browserLaunchMap: any = { darwin: "open", linux: "xdg-open", win32: "start
 export function activate(context: vscode.ExtensionContext) {
 	let ecmPrint = vscode.workspace.getConfiguration("print", null).editorContextMenuItemPosition;
 	vscode.commands.executeCommand("setContext", "ecmPrint", ecmPrint);
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(checkConfigurationChange));
 	let disposable = vscode.commands.registerCommand("extension.print", async (cmdArgs: any) => {
 		commandArgs = cmdArgs;
 		let editor = vscode.window.activeTextEditor;
@@ -70,6 +71,16 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 	context.subscriptions.push(disposable);
 	return { extendMarkdownIt(mdparam: any) { return md = mdparam; } };
+}
+
+const checkConfigurationChange = (e: vscode.ConfigurationChangeEvent) => {
+    if(e.affectsConfiguration('print.editorContextMenuItemPosition'))
+    {
+        vscode.commands.executeCommand(
+            "setContext", "ecmPrint", 
+            vscode.workspace.getConfiguration("print", null)
+                            .get('editorContextMenuItemPosition') );
+    }
 }
 
 async function getPort(): Promise<number> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,8 +13,10 @@ var commandArgs: any;
 var selection: vscode.Selection | undefined;
 const browserLaunchMap: any = { darwin: "open", linux: "xdg-open", win32: "start" };
 export function activate(context: vscode.ExtensionContext) {
-	let ecmPrint = vscode.workspace.getConfiguration("print", null).editorContextMenuItemPosition;
+	let ecmPrint = vscode.workspace.getConfiguration("print", null).editorContextMenuItemPosition,
+        etmButton = vscode.workspace.getConfiguration("print", null).editorTitleMenuButton;
 	vscode.commands.executeCommand("setContext", "ecmPrint", ecmPrint);
+	vscode.commands.executeCommand("setContext", "etmButton", etmButton);
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(checkConfigurationChange));
 	let disposable = vscode.commands.registerCommand("extension.print", async (cmdArgs: any) => {
 		commandArgs = cmdArgs;
@@ -79,6 +81,12 @@ const checkConfigurationChange = (e: vscode.ConfigurationChangeEvent) => {
             "setContext", "ecmPrint", 
             vscode.workspace.getConfiguration("print", null)
                             .get('editorContextMenuItemPosition') );
+    }
+    if(e.affectsConfiguration('print.editorTitleMenuButton')) {
+        vscode.commands.executeCommand(
+            "setContext", "etmButton", 
+            vscode.workspace.getConfiguration("print", null)
+                            .get<boolean>('editorTitleMenuButton') );
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,8 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 const checkConfigurationChange = (e: vscode.ConfigurationChangeEvent) => {
-    if(e.affectsConfiguration('print.editorContextMenuItemPosition'))
-    {
+    if(e.affectsConfiguration('print.editorContextMenuItemPosition')) {
         vscode.commands.executeCommand(
             "setContext", "ecmPrint", 
             vscode.workspace.getConfiguration("print", null)


### PR DESCRIPTION
  - Added an onDidChangeConfiguration subscription that updates the context `print.editorContextMenuItemPosition` (which otherwise requires a restart to reflect changes in UI, at least that's what I've been doing lol)
  - New configuration point `print.editorTitleMenuButton` to control visibility of the editor title print command button, updated manual and added to above subscription
  - `print.colourScheme`'s title updated to existing nls?