### PR TITLE
Add support for printing entire folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-print",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       },
       {
         "category": "%commands.category%",
+        "command": "extension.printFolder",
+        "title": "%commands.title.printFolder%"
+      },
+      {
+        "category": "%commands.category%",
         "command": "extension.browse",
         "title": "%commands.title.browse%"
       },
@@ -130,6 +135,27 @@
             "default": true,
             "type": "boolean",
             "description": "%print.editorTitleMenuButton.description%"
+          },
+          "print.folder.fileNames": {
+            "default": true,
+            "type": "boolean",
+            "title": "%print.folder.fileNames.title%",
+            "description": "%print.folder.fileNames.description%"
+          },
+          "print.folder.include": {
+            "default": null,
+            "type": "string",
+            "description": "%print.folder.include%"
+          },
+          "print.folder.exclude": {
+            "default": ["node_modules/**", "dist/**"],
+            "type": "array",
+            "description": "%print.folder.exclude%"
+          },
+          "print.folder.maxLines": {
+            "default": 1200,
+            "type": "integer",
+            "description": "%print.folder.maxLines%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
   "configuration.title.print": "Printing",
   "commands.category": "Printing",
   "commands.title.print": "Print",
+  "commands.title.printFolder": "Print Folder",
   "commands.title.browse": "Browse for stylesheets",
   "commands.title.help": "Open the manual",
   "print.renderMarkdown.title": "Render Markdown",
@@ -25,5 +26,10 @@
   "print.lineSpacing.description": "Vertical spacing of lines",
   "print.lineSpacing.single": "Single spaced",
   "print.lineSpacing.line-and-a-half": "Line and a half",
-  "print.lineSpacing.double": "Double spaced"
+  "print.lineSpacing.double": "Double spaced",
+  "print.folder.fileNames.title": "Print file names",
+  "print.folder.fileNames.description": "Should file names be printed between each code file.",
+  "print.folder.include": "Pattern to include when printing. Empty includes everything.",
+  "print.folder.exclude": "Patterns to exclude when printing.",
+  "print.folder.maxLines": "Files with more lines than this will be ignored."
 }


### PR DESCRIPTION
Allows you to print the contents of a folder by using the "Printing: Print Folder" command.
This will create a printable HTML document with the code of each file and the file's title (can be disabled).