### PR TITLE
Only allow web server connections to localhost addresses

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -89,6 +89,10 @@ The setting points at the the cached copy, so if you make changes you must repea
 
 Don't use dark theme stylesheets. Paper is white.
 
+## Web Server
+
+Note that the web server only allows connections to localhost.  Connections not to localhost will be rejected.
+
 ## Katex markdown extension
 This depends on CSS and fonts from the web. To get printing to work you must add the required stylesheet to your settings.
 


### PR DESCRIPTION
This code should only allow connections that are connecting to a localhost address.  I included the standard localhost IPs, as also do a DNS lookup just in case the OS has a unique localhost configuration.  I have support for IPv4, IPv6, and IPv4-mapped-to-IPv6.

I think this needs to be tested on as many configurations as feasible, to avoid this change from breaking for anyone.

I have tested this on Ubuntu 18.04 using both Firefox and Chrome.  