### PR TITLE
Display error message when browser launch fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,10 @@ async function print(filePath: string) {
 
   let printConfig = vscode.workspace.getConfiguration("print", null);
   let cmd = printConfig.alternateBrowser && printConfig.browserPath ? `"${printConfig.browserPath}"` : browserLaunchMap[process.platform];
-  child_process.exec(`${cmd} http://localhost:${port}/`);
+  child_process.exec(`${cmd} http://localhost:${port}/`,(error: child_process.ExecException | null, stdout: string, stderr: string) => {
+    vscode.window.showErrorMessage(`Error Attempting to Print: ${error ? error.message : stderr}`);
+    console.error("Print Error: " + error);
+  } );
 }
 
 function getFileText(fname: string): string {


### PR DESCRIPTION
Nothing is displayed when the browser fails to launch (which can be frustrating when trying to figure out what is wrong with the configuration).  This PR is just a suggestion to display an error notification with the error details.  Here is how it would look:

![image](https://user-images.githubusercontent.com/5075659/116002113-28b52580-a5c6-11eb-9cfa-d1b53f41ea19.png)

![image](https://user-images.githubusercontent.com/5075659/116002131-38cd0500-a5c6-11eb-97d5-45151091d591.png)
