### PR TITLE
[Patch] Fixing the line start with padding instead of margin

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,7 +229,7 @@ table {
   vertical-align: top;
 }
 .line-text {
-  margin-left: 0.7em;
+  padding-left: 0.7em;
   padding-bottom: {lineSpacing}em;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Table cells cannot accept a margin attribute...
ref: https://developer.mozilla.org/en-US/docs/Web/CSS/margin